### PR TITLE
Update SDK to use guzzle 3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php"                     : ">=5.3.2",
         "doctrine/common"         : "~2.0",
-        "guzzle/guzzle"           : "~2.7",
+        "guzzle/guzzle"           : "~3.0",
         "monolog/monolog"         : "~1.0",
         "symfony/http-foundation" : "~2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "ba6eb9d32192d327849ca9878434854b",
+    "hash": "49d78931700e24e38cbeeca7f5845a36",
     "packages": [
         {
             "name": "doctrine/common",
@@ -72,42 +72,63 @@
         },
         {
             "name": "guzzle/guzzle",
-            "version": "v2.8.8",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle",
-                "reference": "v2.8.8"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "v3.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/guzzle/guzzle/zipball/v2.8.8",
-                "reference": "v2.8.8",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/v3.3.1",
+                "reference": "v3.3.1",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "php": ">=5.3.2",
-                "symfony/event-dispatcher": "2.1.*"
+                "symfony/event-dispatcher": ">=2.1"
             },
             "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
                 "guzzle/common": "self.version",
                 "guzzle/http": "self.version",
-                "guzzle/parser": "self.version"
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
             },
             "require-dev": {
-                "doctrine/common": "*",
+                "doctrine/cache": "*",
                 "monolog/monolog": "1.*",
+                "phpunit/phpunit": "3.7.*",
                 "symfony/class-loader": "*",
                 "zend/zend-cache1": "1.12",
                 "zend/zend-log1": "1.12",
-                "zendframework/zend-cache": "2.0.0beta4",
-                "zendframework/zend-eventmanager": "2.0.0beta4",
-                "zendframework/zend-loader": "2.0.0beta4",
-                "zendframework/zend-log": "2.0.0beta4",
-                "zendframework/zend-servicemanager": "2.0.0beta4",
-                "zendframework/zend-stdlib": "2.0.0beta4"
+                "zendframework/zend-cache": "2.0.*",
+                "zendframework/zend-log": "2.0.*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Guzzle\\Tests": "tests/",
@@ -140,7 +161,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2012-10-15 17:25:16"
+            "time": "2013-03-10 23:05:38"
         },
         {
             "name": "monolog/monolog",
@@ -244,33 +265,38 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.1.8",
+            "version": "v2.2.0",
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "v2.1.8"
+                "reference": "v2.2.0-RC3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/v2.1.8",
-                "reference": "v2.1.8",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "symfony/dependency-injection": "2.1.*"
+                "symfony/dependency-injection": ">=2.0,<3.0"
             },
             "suggest": {
-                "symfony/dependency-injection": "2.1.*",
-                "symfony/http-kernel": "2.1.*"
+                "symfony/dependency-injection": "2.2.*",
+                "symfony/http-kernel": "2.2.*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
-                    "Symfony\\Component\\EventDispatcher": ""
+                    "Symfony\\Component\\EventDispatcher\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -289,7 +315,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
-            "time": "2013-02-11 11:26:14"
+            "time": "2013-02-11 11:26:43"
         },
         {
             "name": "symfony/http-foundation",

--- a/src/PhraseanetSDK/HttpAdapter/Guzzle.php
+++ b/src/PhraseanetSDK/HttpAdapter/Guzzle.php
@@ -2,7 +2,7 @@
 
 namespace PhraseanetSDK\HttpAdapter;
 
-use Guzzle\Common\GuzzleException;
+use Guzzle\Common\Exception\GuzzleException;
 use Guzzle\Http\Client;
 use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Exception\BadResponseException as GuzzleBadResponse;

--- a/tests/Test/GuzzleClientTest.php
+++ b/tests/Test/GuzzleClientTest.php
@@ -3,7 +3,7 @@
 namespace Test;
 
 use Guzzle\Http\Client;
-use Guzzle\Http\Plugin\MockPlugin;
+use Guzzle\Plugin\Mock\MockPlugin;
 use Guzzle\Http\Message\Response;
 use PhraseanetSDK\HttpAdapter\Guzzle as Adapter;
 

--- a/tests/Test/Repository/Repository.php
+++ b/tests/Test/Repository/Repository.php
@@ -5,7 +5,7 @@ namespace Test\Repository;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhraseanetSDK\Client;
 use PhraseanetSDK\HttpAdapter\Guzzle as GuzzleAdapter;
-use Guzzle\Http\Plugin\MockPlugin;
+use Guzzle\Plugin\Mock\MockPlugin;
 use Guzzle\Http\Message\Response;
 use Guzzle\Http\Client as GuzzleClient;
 use Monolog\Logger;


### PR DESCRIPTION
If you look b65b2a9543fc2954943426126abea7bed3f06483 The _alchemy-fr/Phraseanet-PHP-SDK-Silex-Provider_ has been updated to use Guzzle 3.\* **but do not precise the requirement of guzzle >3.0 in the composer.json** https://github.com/alchemy-fr/Phraseanet-PHP-SDK-Silex-Provider/blob/master/composer.json and if you look cf7e53bc97f89edc4d25328ee3fce4246ee7135b The _alchemy-fr/Phraseanet-PHP-SDK_ has been updated to use >=2.7,<3.0.

So when you use both of them and update dependencies there is no error,  but you can not no longer use the _alchemy-fr/Phraseanet-PHP-SDK-Silex-Provider_ because it is not able to work with guzzle <3.0.

So I've updated  _alchemy-fr/Phraseanet-PHP-SDK_ to use at least guzzle 3.0 and will a do a PR to require guzzle >3.0 dependency in the  _alchemy-fr/Phraseanet-PHP-SDK-Silex-Provider_ when this PR will be merged because it require  _alchemy-fr/Phraseanet-PHP-SDK_ to use Guzzle >3.0
