### PR TITLE
Add Id Annotation

### DIFF
--- a/src/PhraseanetSDK/Annotation/Id.php
+++ b/src/PhraseanetSDK/Annotation/Id.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Phraseanet SDK.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhraseanetSDK\Annotation;
+
+/** @Annotation */
+class Id
+{
+}

--- a/src/PhraseanetSDK/Entity/Basket.php
+++ b/src/PhraseanetSDK/Entity/Basket.php
@@ -14,11 +14,12 @@ namespace PhraseanetSDK\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
-use PhraseanetSDK\Annotation\Id;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Basket
 {
     /**
+     * @Id
      * @ApiField(bind_to="basket_id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/BasketElement.php
+++ b/src/PhraseanetSDK/Entity/BasketElement.php
@@ -14,10 +14,12 @@ namespace PhraseanetSDK\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class BasketElement
 {
     /**
+     * @Id
      * @ApiField(bind_to="basket_element_id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/Databox.php
+++ b/src/PhraseanetSDK/Entity/Databox.php
@@ -12,11 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Databox
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="databox_id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/DataboxCollection.php
+++ b/src/PhraseanetSDK/Entity/DataboxCollection.php
@@ -12,10 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class DataboxCollection
 {
     /**
+     * @Id
      * @ApiField(bind_to="base_id", type="int")
      */
     protected $baseId;

--- a/src/PhraseanetSDK/Entity/DataboxDocumentStructure.php
+++ b/src/PhraseanetSDK/Entity/DataboxDocumentStructure.php
@@ -12,11 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class DataboxDocumentStructure
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/DataboxStatus.php
+++ b/src/PhraseanetSDK/Entity/DataboxStatus.php
@@ -12,10 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class DataboxStatus
 {
     /**
+     * @Id
      * @ApiField(bind_to="bit", type="int")
      */
     protected $bit;

--- a/src/PhraseanetSDK/Entity/DataboxTermsOfUse.php
+++ b/src/PhraseanetSDK/Entity/DataboxTermsOfUse.php
@@ -12,10 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class DataboxTermsOfUse
 {
     /**
+     * @Id
      * @ApiField(bind_to="locale", type="string")
      */
     protected $locale;

--- a/src/PhraseanetSDK/Entity/Feed.php
+++ b/src/PhraseanetSDK/Entity/Feed.php
@@ -14,10 +14,12 @@ namespace PhraseanetSDK\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Feed
 {
     /**
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/FeedEntry.php
+++ b/src/PhraseanetSDK/Entity/FeedEntry.php
@@ -14,11 +14,12 @@ namespace PhraseanetSDK\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class FeedEntry
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/FeedEntryItem.php
+++ b/src/PhraseanetSDK/Entity/FeedEntryItem.php
@@ -13,11 +13,12 @@ namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class FeedEntryItem
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="item_id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/Metadata.php
+++ b/src/PhraseanetSDK/Entity/Metadata.php
@@ -12,11 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Metadata
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="meta_id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/Permalink.php
+++ b/src/PhraseanetSDK/Entity/Permalink.php
@@ -12,11 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Permalink
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/Quarantine.php
+++ b/src/PhraseanetSDK/Entity/Quarantine.php
@@ -14,11 +14,12 @@ namespace PhraseanetSDK\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Quarantine
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/QuarantineSession.php
+++ b/src/PhraseanetSDK/Entity/QuarantineSession.php
@@ -13,11 +13,12 @@ namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class QuarantineSession
 {
     /**
-     *
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/Entity/RecordCaption.php
+++ b/src/PhraseanetSDK/Entity/RecordCaption.php
@@ -12,10 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class RecordCaption
 {
     /**
+     * @Id
      * @ApiField(bind_to="meta_structure_id", type="int")
      */
     protected $metaStructureId;

--- a/src/PhraseanetSDK/Entity/RecordStatus.php
+++ b/src/PhraseanetSDK/Entity/RecordStatus.php
@@ -12,10 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class RecordStatus
 {
     /**
+     * @Id
      * @ApiField(bind_to="bit", type="int")
      */
     protected $bit;

--- a/src/PhraseanetSDK/Entity/Subdef.php
+++ b/src/PhraseanetSDK/Entity/Subdef.php
@@ -13,10 +13,12 @@ namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
 use PhraseanetSDK\Annotation\ApiRelation as ApiRelation;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class Subdef
 {
     /**
+     * @Id
      * @ApiField(bind_to="name", type="string")
      */
     protected $name;

--- a/src/PhraseanetSDK/Entity/User.php
+++ b/src/PhraseanetSDK/Entity/User.php
@@ -12,10 +12,12 @@
 namespace PhraseanetSDK\Entity;
 
 use PhraseanetSDK\Annotation\ApiField as ApiField;
+use PhraseanetSDK\Annotation\Id as Id;
 
 class User
 {
     /**
+     * @Id
      * @ApiField(bind_to="id", type="int")
      */
     protected $id;

--- a/src/PhraseanetSDK/EntityManager.php
+++ b/src/PhraseanetSDK/EntityManager.php
@@ -155,5 +155,6 @@ class EntityManager
         AnnotationRegistry::registerFile(__DIR__.'/Annotation/ApiField.php');
         AnnotationRegistry::registerFile(__DIR__.'/Annotation/ApiObject.php');
         AnnotationRegistry::registerFile(__DIR__.'/Annotation/ApiRelation.php');
+        AnnotationRegistry::registerFile(__DIR__.'/Annotation/Id.php');
     }
 }


### PR DESCRIPTION
This feature allows to identify array collections.

for subdefs collections as an example:
before:
[{//subdef object}, {//subdef object}]

and to find the preview in subdef collection:
```php
$subdefs =$record->getSubdefs();
$previewCollection = subdefs->filter(function($subdef) {
    return $subdef->getName() === 'preview';
});
$preview = $previewCollection->count() > 0 ? $previewCollection->first() : null;
```

now:
the subdefName property is tagged as id so
['document => {//subdef object}, 'preview' => {//subdef object}]
```php
$subdefs = $record->getSubdefs();
$preview = $subdefs->has('preview') ? subdefs->get('preview') : null;
```