### PR TITLE
Fix incorrect request time display in profiler

### DIFF
--- a/src/PhraseanetSDK/Profiler/resources/views/Profiler/call.html.twig
+++ b/src/PhraseanetSDK/Profiler/resources/views/Profiler/call.html.twig
@@ -4,7 +4,7 @@
     <div class="summary">
         <h3>
             <span class="method">{{ call.request.method }}</span>
-            <span class="time">&nbsp{{ call.time.total ?: 0 }} ms</span
+            <span class="time">&nbsp{{ call.time.total * 1000 ?: 0 }} ms</span>
             <span class="path">&nbsp{{ call.request.path }}</span>
         </h3>
         <div class="code">


### PR DESCRIPTION
Request times were displayed in seconds, with a unit indicator of ms
Fixes issue by displaying request times in ms