### PR TITLE
Revert "Index metadata values by name, not meta ID"

### DIFF
--- a/src/PhraseanetSDK/Entity/Metadata.php
+++ b/src/PhraseanetSDK/Entity/Metadata.php
@@ -19,7 +19,7 @@ class Metadata
         $metadata = array();
 
         foreach ($values as $value) {
-            $metadata[$value->name] = self::fromValue($value);
+            $metadata[$value->meta_id] = self::fromValue($value);
         }
 
         return $metadata;


### PR DESCRIPTION
Reverts alchemy-fr/Phraseanet-PHP-SDK#77

Introduced bug with multivalued fields