### PR TITLE
PARADE-744 | Choose api version when using search route

### DIFF
--- a/src/PhraseanetSDK/Entity/Query.php
+++ b/src/PhraseanetSDK/Entity/Query.php
@@ -189,4 +189,15 @@ class Query
     {
         return $this->results ?: $this->results = Result::fromValue($this->entityManager, $this->source->results);
     }
+
+	/**
+	 * Set or override value in protected object 'source' (\stdClass type)
+	 *
+	 * @param $pKey	string
+	 * @param $pValue mixed
+	 */
+    public function setSourceEntry($pKey, $pValue)
+	{
+		$this->source->$pKey = $pValue;
+	}
 }

--- a/src/PhraseanetSDK/Repository/Record.php
+++ b/src/PhraseanetSDK/Repository/Record.php
@@ -74,12 +74,13 @@ class Record extends AbstractRepository
      * Search for records
      *
      * @param  array                       $parameters Query parameters
+	 * @param int                          $pAPINumber API number (e.g. 3)
      * @return \PhraseanetSDK\Entity\Query object
      * @throws RuntimeException
      */
-    public function search(array $parameters = array())
+    public function search(array $parameters = array(), $pAPINumber = 1)
     {
-        $response = $this->query('POST', 'v1/search/', array(), array_merge(
+		$response = $this->query('POST', 'v'.$pAPINumber.'/search/', array(), array_merge(
             array('search_type' => 0),
             $parameters
         ));

--- a/src/PhraseanetSDK/Repository/Story.php
+++ b/src/PhraseanetSDK/Repository/Story.php
@@ -15,6 +15,7 @@ use PhraseanetSDK\AbstractRepository;
 use PhraseanetSDK\Entity\Query;
 use PhraseanetSDK\Exception\RuntimeException;
 use Doctrine\Common\Collections\ArrayCollection;
+use PhraseanetSDK\Search\SearchResult;
 
 class Story extends AbstractRepository
 {
@@ -51,7 +52,7 @@ class Story extends AbstractRepository
     {
         $response = $this->query('POST', 'v1/search/', array(), array(
             'query'        => '',
-            'search_type'  => 1,
+            'search_type'  => SearchResult::TYPE_STORY,
             'offset_start' => (int) $offsetStart,
             'per_page'     => (int) $perPage,
         ));
@@ -67,14 +68,15 @@ class Story extends AbstractRepository
      * Search for stories
      *
      * @param  array $parameters Query parameters
+	 * @param int $pAPINumber API number (e.g. 3)
      * @return \PhraseanetSDK\Entity\Query object
      * @throws RuntimeException
      */
-    public function search(array $parameters = array())
+    public function search(array $parameters = array(), $pAPINumber = 1)
     {
-        $response = $this->query('POST', 'v1/search/', array(), array_merge(
-            array('search_type' => 2),
-            $parameters
+        $response = $this->query('POST', 'v'.$pAPINumber.'/search/', array(), array_merge(
+            $parameters,
+			array('search_type' => SearchResult::TYPE_STORY)
         ));
 
         if ($response->isEmpty()) {


### PR DESCRIPTION
## Changelog

### Changes
- PARADE-744:#comment Choose API version when using search route.

### Adds
- PARADE-744:#comment add setSourceEntry to change response data from external process (e.g. parade-bunndle-phraseanet).